### PR TITLE
serialize/deserialize report data

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires "DBIx::Class" => "0";
 requires "DBIx::Class::Candy" => "0";
+requires "DBIx::Class::InflateColumn::Serializer" => "0.09";
 requires "DateTime" => "0";
 requires "DateTime::Format::ISO8601" => "0";
 requires "File::Share" => "0";

--- a/dist.ini
+++ b/dist.ini
@@ -137,6 +137,7 @@ File::Share = 0
 Path::Tiny = 0.072 ; Fixes issues with File::Path
 SQL::Translator = 0.11018 ; Allows deploying the schema
 JSON::MaybeXS = 0
+DBIx::Class::InflateColumn::Serializer = 0.09
 
 ;-- Common prereqs with minimum version requirements
 ;List::Util = 1.29 ; First version with pair* functions

--- a/lib/CPAN/Testers/Schema/Result/TestReport.pm
+++ b/lib/CPAN/Testers/Schema/Result/TestReport.pm
@@ -26,6 +26,8 @@ use Data::UUID;
 use DateTime;
 table 'test_report';
 
+__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
+
 =attr id
 
 The UUID of this report stored in standard hex string representation.
@@ -60,8 +62,10 @@ format on http://api.cpantesters.org
 =cut
 
 column 'report', {
-    data_type => 'JSON',
-    is_nullable => 0,
+    data_type            => 'JSON',
+    is_nullable          => 0,
+    'serializer_class'   => 'JSON',
+    'serializer_options' => { allow_blessed => 1, convert_blessed => 1 }
 };
 
 =method new

--- a/lib/CPAN/Testers/Schema/Result/TestReport.pm
+++ b/lib/CPAN/Testers/Schema/Result/TestReport.pm
@@ -79,8 +79,8 @@ fields.
 =cut
 
 sub new( $class, $attrs ) {
-    $attrs->{id} ||= Data::UUID->new->create_str;
-    $attrs->{created} ||= DateTime->now( time_zone => 'UTC' )->datetime . 'Z';
+    $attrs->{report}{id} = $attrs->{id} ||= Data::UUID->new->create_str;
+    $attrs->{report}{created} = $attrs->{created} ||= DateTime->now( time_zone => 'UTC' )->datetime . 'Z';
     return $class->next::method( $attrs );
 };
 

--- a/lib/CPAN/Testers/Schema/ResultSet/TestReport.pm
+++ b/lib/CPAN/Testers/Schema/ResultSet/TestReport.pm
@@ -21,7 +21,6 @@ L<CPAN::Testers::Schema>
 
 use CPAN::Testers::Schema::Base 'ResultSet';
 use Scalar::Util qw( blessed );
-use JSON::MaybeXS qw( encode_json );
 
 =method insert_metabase_fact
 
@@ -74,7 +73,7 @@ sub insert_metabase_fact( $self, $fact ) {
     return $self->create({
         id => $fact->guid,
         created => $fact->creation_time,
-        report => encode_json( \%report ),
+        report => \%report,
     });
 }
 

--- a/t/result/test_report.t
+++ b/t/result/test_report.t
@@ -20,6 +20,8 @@ subtest 'column defaults' => sub {
         'GUID is created automatically';
     like $row->created, qr{\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z},
         'row created in Y-M-DTH:M:S';
+    is $row->report->{id}, $row->id, 'id field added to report';
+    is $row->report->{created}, $row->created, 'created field added to report';
 };
 
 done_testing;

--- a/t/result/test_report.t
+++ b/t/result/test_report.t
@@ -15,7 +15,7 @@ my $schema = prepare_temp_schema;
 my $HEX = qr{[A-Fa-f0-9]};
 
 subtest 'column defaults' => sub {
-    my $row = $schema->resultset( 'TestReport' )->create( { report => '{}' } );
+    my $row = $schema->resultset( 'TestReport' )->create( { report => {} } );
     like $row->id, qr{${HEX}{8}-${HEX}{4}-${HEX}{4}-${HEX}{4}-${HEX}{12}},
         'GUID is created automatically';
     like $row->created, qr{\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z},

--- a/t/resultset/test_report.t
+++ b/t/resultset/test_report.t
@@ -60,7 +60,7 @@ subtest 'insert_metabase_fact' => sub {
         },
     };
     my $row = $schema->resultset( 'TestReport' )->insert_metabase_fact( $given_report );
-    is_deeply decode_json($row->report), $expect_report, 'Metabase::Fact is converted correctly';
+    is_deeply $row->report, $expect_report, 'Metabase::Fact is converted correctly';
 };
 
 done_testing;

--- a/t/resultset/test_report.t
+++ b/t/resultset/test_report.t
@@ -60,7 +60,15 @@ subtest 'insert_metabase_fact' => sub {
         },
     };
     my $row = $schema->resultset( 'TestReport' )->insert_metabase_fact( $given_report );
-    is_deeply $row->report, $expect_report, 'Metabase::Fact is converted correctly';
+
+    my $got_report = $row->report;
+    my $id = delete $got_report->{id};
+    is $id, $given_report->core_metadata->{guid}, 'id is correct';
+
+    my $created = delete $got_report->{created};
+    is $created, $given_report->core_metadata->{creation_time};
+
+    is_deeply $got_report, $expect_report, 'Metabase::Fact is converted correctly';
 };
 
 done_testing;


### PR DESCRIPTION
Since we're storing the report in JSON format, we should be able to easily insert/fetch it. This patch provides such serialization support.