### PR TITLE
add insert_test_report for (new) Stats resultset class

### DIFF
--- a/lib/CPAN/Testers/Schema/ResultSet/Stats.pm
+++ b/lib/CPAN/Testers/Schema/ResultSet/Stats.pm
@@ -1,0 +1,77 @@
+use utf8;
+package CPAN::Testers::Schema::ResultSet::Stats;
+our $VERSION = '0.009';
+# ABSTRACT: Query the raw test reports
+
+=head1 SYNOPSIS
+
+    my $rs = $schema->resultset( 'Stats' );
+    $rs->insert_test_report( $schema->resultset( 'TestReport' )->first );
+
+=head1 DESCRIPTION
+
+This object helps to insert and query the legacy test reports (cpanstats).
+
+=head1 SEE ALSO
+
+L<CPAN::Testers::Schema::Result::Stats>, L<DBIx::Class::ResultSet>,
+L<CPAN::Testers::Schema>
+
+=cut
+
+use CPAN::Testers::Schema::Base 'ResultSet';
+use Log::Any '$LOG';
+
+=method insert_test_report
+
+    my $stat = $rs->insert_test_report( $report );
+
+Convert a L<CPAN::Testers::Schema::Result::TestReport> object to the new test
+report structure and insert it into the database. This is for creating
+backwards-compatible APIs.
+
+Returns an instance of L<CPAN::Testers::Schema::Result::Stats> on success.
+Note that since an uploadid is required for the cpanstats table, this method
+throws an exception when an upload cannot be determined from the given
+information.
+
+=cut
+
+sub insert_test_report ( $self, $report ) {
+    my $schema = $self->result_source->schema;
+
+    my $guid = $report->id;
+    my $data = $report->report;
+    my $created = $report->created;
+
+    # attempt to find an uploadid, which is required for cpanstats
+    my @uploads = $schema->resultset('Upload')->search({
+        dist => $data->{distribution}{name},
+        version => $data->{distribution}{version},
+    })->all;
+
+    die $LOG->warn("No upload match for GUID $guid") unless @uploads;
+    $LOG->warn("Multiple upload matches for GUID $guid") if @uploads > 1;
+    my $uploadid = $uploads[0]->uploadid;
+
+    my $stat = {
+        guid => $guid,
+        state => lc($data->{results}{grade}),
+        postdate => $created->strftime('%Y%m'),
+        tester => qq["$data->{reporter}{name}" <$data->{reporter}{email}>],
+        dist => $data->{distribution}{name},
+        version => $data->{distribution}{version},
+        platform => $data->{environment}{language}{archname},
+        perl => $data->{environment}{language}{version},
+        osname => $data->{environment}{system}{osname},
+        osvers => $data->{environment}{system}{osversion},
+        fulldate => $created->strftime('%Y%m%d%H%M'),
+        type => 2,
+        uploadid => $uploadid,
+    };
+
+    return $schema->resultset('Stats')->create($stat);
+}
+
+1;
+

--- a/t/resultset/stats.t
+++ b/t/resultset/stats.t
@@ -1,0 +1,100 @@
+
+=head1 DESCRIPTION
+
+This file tests the L<CPAN::Testers::Schema::ResultSet::Stats> module which
+queries for L<CPAN::Testers::Schema::Result::Stats> objects.
+
+=head1 SEE ALSO
+
+L<DBIx::Class::ResultSet>
+
+=cut
+
+use CPAN::Testers::Schema::Base 'Test';
+use CPAN::Testers::Schema;
+
+use Scalar::Util 'looks_like_number';
+
+my $schema = CPAN::Testers::Schema->connect( 'dbi:SQLite::memory:', undef, undef, { ignore_version => 1 } );
+$schema->deploy;
+my $rs = $schema->resultset('Stats');
+
+subtest 'insert_test_report' => sub {
+    my $report = $schema->resultset('TestReport')->create({
+        id => 'd0ab4d36-3343-11e7-b830-917e22bfee97',
+        created => DateTime->new(
+            year => 2017,
+            month => 05,
+            day => 07,
+            hour => 16,
+            minute => 40,
+        ),
+        report => {
+            reporter => {
+                name  => 'Andreas J. Koenig',
+                email => 'andreas.koenig.gmwojprw@franz.ak.mind.de',
+            },
+            environment => {
+                system => {
+                    osname => 'linux',
+                    osversion => '4.8.0-2-amd64',
+                },
+                language => {
+                    name => 'Perl 5',
+                    version => '5.22.2',
+                    archname => 'x86_64-linux',
+                },
+            },
+            distribution => {
+                name => 'Sorauta-SVN-AutoCommit',
+                version => '0.02',
+            },
+            results => {
+                grade => 'FAIL',
+            },
+        },
+    });
+
+    subtest 'upload does not exist' => sub {
+        my $stat = eval { $rs->insert_test_report($report) };
+        my $err = $@;
+        ok !$stat, 'stat record was not created';
+        like $err, qr'No upload match for GUID d0ab4d36-3343-11e7-b830-917e22bfee97', 'correct error';
+    };
+
+    my $upload = $schema->resultset('Upload')->create({
+        uploadid => 169497,
+        type => 'cpan',
+        author => 'YUKI',
+        dist => 'Sorauta-SVN-AutoCommit',
+        version => 0.02,
+        filename => 'Sorauta-SVN-AutoCommit-0.02.tar.gz',
+        released => 1327657454,
+    });
+
+    subtest 'upload exists' => sub {
+        my $stat = $rs->insert_test_report($report);
+
+        isa_ok $stat, 'CPAN::Testers::Schema::Result::Stats';
+        ok looks_like_number($stat->id), 'an id was generated';
+        is $stat->guid, 'd0ab4d36-3343-11e7-b830-917e22bfee97', 'correct guid';
+        is $stat->state, 'fail', 'correct test state';
+        is $stat->postdate, 201705, 'correct postdate';
+        is $stat->tester, '"Andreas J. Koenig" <andreas.koenig.gmwojprw@franz.ak.mind.de>', 'correct tester';
+        is $stat->dist, 'Sorauta-SVN-AutoCommit', 'correct dist';
+        is $stat->version, '0.02', 'correct version';
+        is $stat->platform, 'x86_64-linux', 'correct platform';
+        is $stat->perl, '5.22.2', 'correct perl';
+        is $stat->osname, 'linux', 'correct osname';
+        is $stat->osvers, '4.8.0-2-amd64', 'correct osvers';
+        is $stat->fulldate, 201705071640, 'correct fulldate';
+        is $stat->type, 2, 'correct type';
+        is $stat->uploadid, 169497, 'correct uploadid';
+    };
+
+};
+
+done_testing;
+
+
+


### PR DESCRIPTION
This will perform the "heavy lifting" of inserting the new reports back
to the existing cpanstats table needed by
https://github.com/cpan-testers/cpantesters-backend/issues/1