### PR TITLE
Release maturity

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@ Changelog for CPAN-Testers-Schema
 
 {{ $NEXT }}
 
+    - Implement support for `maturity` search param for Release queries.
+
 0.020     2017-11-18 20:44:13-06:00 America/Chicago
 
     [Changed]

--- a/README.mkdn
+++ b/README.mkdn
@@ -69,6 +69,7 @@ directory. These versions can then be upgraded to using the
 - Breno G. de Oliveira <garu@cpan.org>
 - Joel Berger <joel.a.berger@gmail.com>
 - Mohammad S Anwar <mohammad.anwar@yahoo.com>
+- Nick Tonkin <nick@nicktonkin.net>
 
 # COPYRIGHT AND LICENSE
 

--- a/lib/CPAN/Testers/Schema/ResultSet/Release.pm
+++ b/lib/CPAN/Testers/Schema/ResultSet/Release.pm
@@ -9,6 +9,7 @@ our $VERSION = '0.021';
     $rs->by_dist( 'My-Dist' );
     $rs->by_author( 'PREACTION' );
     $rs->since( '2016-01-01T00:00:00' );
+    $rs->maturity( 'stable' );
 
 =head1 DESCRIPTION
 
@@ -63,6 +64,21 @@ sub since( $self, $date ) {
     my $fulldate = $date =~ s/[-:T]//gr;
     $fulldate = substr $fulldate, 0, 12; # 12 digits makes YYYYMMDDHHNN
     return $self->search( { 'report.fulldate' => { '>=', $fulldate } }, { join => 'report' } );
+}
+
+=method maturity
+
+    $rs = $rs->maturity( 'stable' );
+
+Restrict results to only those dists that are stable. Also supported:
+'dev' to restrict to only development dists.
+
+=cut
+
+sub maturity( $self, $maturity ) {
+    my %map = ( 'stable' => 1, 'dev' => 2 );
+    $maturity = $map{ $maturity };
+    return $self->search( { 'me.distmat' => $maturity } );
 }
 
 1;

--- a/t/resultset/release.t
+++ b/t/resultset/release.t
@@ -217,6 +217,38 @@ $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
 is_deeply [ $rs->all ], $data{Release}, 'sanity check that items were inserted'
     or diag explain [ $rs->all ];
 
+subtest 'since' => sub {
+    my $rs = $schema->resultset( 'Release' )->since( '2016-08-20T00:00:00' );
+    $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
+    is_deeply [ $rs->all ], [ $data{Release}->@[1..3] ], 'get items since 2016-08-20'
+        or diag explain [ $rs->all ];
+};
+
+subtest 'maturity' => sub {
+    subtest 'stable only' => sub {
+        my $rs = $schema->resultset( 'Release' )->maturity( 'stable' );
+        $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
+        is_deeply [ $rs->all ], [ $data{Release}->@[0..2] ], 'get only stable items'
+            or diag explain [ $rs->all ];
+    };
+
+    subtest 'development only' => sub {
+        my $rs = $schema->resultset( 'Release' )->maturity( 'dev' );
+        $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
+        is_deeply [ $rs->all ], [ $data{Release}->@[3] ], 'get only dev items'
+            or diag explain [ $rs->all ];
+    };
+};
+
+subtest 'since and maturity' => sub {
+     my $rs = $schema->resultset( 'Release' )
+       ->since( '2016-08-20T00:00:00' )
+       ->maturity( 'stable' );
+    $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
+    is_deeply [ $rs->all ], [ $data{Release}->@[1..2] ], 'get stable items since 2016-08-20'
+        or diag explain [ $rs->all ];
+};
+
 subtest 'by_dist' => sub {
     my $rs = $schema->resultset( 'Release' )->by_dist( 'My-Dist' );
     $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
@@ -229,8 +261,16 @@ subtest 'by_dist' => sub {
         $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
         is_deeply [ $rs->all ], [ $data{Release}[1] ], 'get items for My-Dist'
             or diag explain [ $rs->all ];
-
     };
+
+    subtest 'maturity' => sub {
+        my $rs = $schema->resultset( 'Release' )->by_dist( 'My-Other' )
+                ->maturity( 'stable' );
+        $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
+        is_deeply [ $rs->all ], [ $data{Release}[2] ], 'get stable items for My-Other'
+            or diag explain [ $rs->all ];
+    };
+
 };
 
 subtest 'by_author' => sub {
@@ -245,15 +285,15 @@ subtest 'by_author' => sub {
         $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
         is_deeply [ $rs->all ], [ $data{Release}->@[2,3] ], 'get items for PREACTION'
             or diag explain [ $rs->all ];
-
     };
-};
 
-subtest 'since' => sub {
-    my $rs = $schema->resultset( 'Release' )->since( '2016-08-20T00:00:00' );
-    $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
-    is_deeply [ $rs->all ], [ $data{Release}->@[1..3] ], 'get items since 2016-08-20'
-        or diag explain [ $rs->all ];
+    subtest 'maturity' => sub {
+        my $rs = $schema->resultset( 'Release' )->by_author( 'PREACTION' )
+                ->maturity( 'dev' );
+        $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
+        is_deeply [ $rs->all ], [ $data{Release}[3] ], 'get dev items for PREACTION'
+            or diag explain [ $rs->all ];
+    };
 };
 
 done_testing;

--- a/t/resultset/release.t
+++ b/t/resultset/release.t
@@ -18,7 +18,6 @@ use CPAN::Testers::Schema::Base 'Test';
 
 my %default = (
     oncpan => 1,
-    distmat => 1,
     perlmat => 1,
     patched => 1,
 );
@@ -61,6 +60,15 @@ my %data = (
             version => '1.000',
             filename => 'My-Other-1.000.tar.gz',
             released => 1479524800,
+        },
+        {
+            uploadid => 4,
+            type => 'cpan',
+            author => 'PREACTION',
+            dist => 'My-Other',
+            version => '1.001',
+            filename => 'My-Other-1.001.tar.gz',
+            released => 1479524900,
         },
     ],
 
@@ -117,11 +125,25 @@ my %data = (
             postdate => '201609',
             fulldate => '201609180000',
         },
+        {
+            %stats_default,
+            # Upload info
+            dist => 'My-Other',
+            version => '1.001',
+            uploadid => 4,
+            # Stats info
+            id => 5,
+            guid => '00000000-0000-0000-0000-000000000005',
+            state => 'pass',
+            postdate => '201609',
+            fulldate => '201609180100',
+        },
     ],
 
     Release => [
         {
             %default,
+            distmat => 1,
             # Upload info
             dist => 'My-Dist',
             version => '1.001',
@@ -137,6 +159,7 @@ my %data = (
         },
         {
             %default,
+            distmat => 1,
             # Upload info
             dist => 'My-Dist',
             version => '1.002',
@@ -152,6 +175,7 @@ my %data = (
         },
         {
             %default,
+            distmat => 1,
             # Upload info
             dist => 'My-Other',
             version => '1.000',
@@ -159,6 +183,22 @@ my %data = (
             # Stats
             id => 4,
             guid => '00000000-0000-0000-0000-000000000004',
+            # Release summary
+            pass => 1,
+            fail => 0,
+            na => 0,
+            unknown => 0,
+        },
+        {
+            %default,
+            distmat => 2,
+            # Upload info
+            dist => 'My-Other',
+            version => '1.001',
+            uploadid => 4,
+            # Stats
+            id => 5,
+            guid => '00000000-0000-0000-0000-000000000005',
             # Release summary
             pass => 1,
             fail => 0,
@@ -196,14 +236,14 @@ subtest 'by_dist' => sub {
 subtest 'by_author' => sub {
     my $rs = $schema->resultset( 'Release' )->by_author( 'PREACTION' );
     $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
-    is_deeply [ $rs->all ], [ $data{Release}->@[0,2] ], 'get items for PREACTION'
+    is_deeply [ $rs->all ], [ $data{Release}->@[0,2,3] ], 'get items for PREACTION'
         or diag explain [ $rs->all ];
 
     subtest 'since' => sub {
         my $rs = $schema->resultset( 'Release' )->by_author( 'PREACTION' )
                 ->since( '2016-08-20T00:00:00' );
         $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
-        is_deeply [ $rs->all ], [ $data{Release}[2] ], 'get items for PREACTION'
+        is_deeply [ $rs->all ], [ $data{Release}->@[2,3] ], 'get items for PREACTION'
             or diag explain [ $rs->all ];
 
     };
@@ -212,7 +252,7 @@ subtest 'by_author' => sub {
 subtest 'since' => sub {
     my $rs = $schema->resultset( 'Release' )->since( '2016-08-20T00:00:00' );
     $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
-    is_deeply [ $rs->all ], [ $data{Release}->@[1,2] ], 'get items since 2016-08-20'
+    is_deeply [ $rs->all ], [ $data{Release}->@[1..3] ], 'get items since 2016-08-20'
         or diag explain [ $rs->all ];
 };
 


### PR DESCRIPTION
Implement a method in `CPAN::Testers::Schema::ResultSet::Release` to restrict results to only stable or only dev dists.

(Note: param value `any` not supported here, since it is the default and will be discarded in the API class if supplied.)