### PR TITLE
Release limit per dist

### DIFF
--- a/lib/CPAN/Testers/Schema/ResultSet/Release.pm
+++ b/lib/CPAN/Testers/Schema/ResultSet/Release.pm
@@ -81,5 +81,31 @@ sub maturity( $self, $maturity ) {
     return $self->search( { 'me.distmat' => $maturity } );
 }
 
+=method limit_per_dist
+
+    $rs = $rs->limit_per_dist( 2 );
+
+Restrict results to a maximum number per distribution.
+
+=cut
+
+sub limit_per_dist( $self, $limit ) {
+    my $rs = $self->search(
+        {
+            -and => [
+                \[ '( SELECT COUNT(*)
+                      FROM uploads
+                      WHERE uploads.dist = me.dist
+                      AND uploads.version >= me.version ) <= ?' => $limit ],
+            ],
+        },
+        { join => 'upload' },
+    );
+
+    use Data::Dumper;
+    #warn Dumper($rs->as_query);
+    return $rs;
+}
+
 1;
 __END__

--- a/lib/CPAN/Testers/Schema/ResultSet/Release.pm
+++ b/lib/CPAN/Testers/Schema/ResultSet/Release.pm
@@ -102,8 +102,6 @@ sub limit_per_dist( $self, $limit ) {
         { join => 'upload' },
     );
 
-    use Data::Dumper;
-    #warn Dumper($rs->as_query);
     return $rs;
 }
 

--- a/t/resultset/release.t
+++ b/t/resultset/release.t
@@ -240,6 +240,15 @@ subtest 'maturity' => sub {
     };
 };
 
+subtest 'limit_per_dist' => sub {
+    my $rs = $schema->resultset( 'Release' )->limit_per_dist( 1 );
+    $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
+    $schema->storage->debug(1);
+    is_deeply [ $rs->all ], [ $data{Release}->@[1,3] ], 'limit 1 results per dist'
+        or diag explain [ $rs->all ];
+    $schema->storage->debug(0);
+};
+
 subtest 'since and maturity' => sub {
      my $rs = $schema->resultset( 'Release' )
        ->since( '2016-08-20T00:00:00' )

--- a/t/resultset/release.t
+++ b/t/resultset/release.t
@@ -280,6 +280,15 @@ subtest 'by_dist' => sub {
             or diag explain [ $rs->all ];
     };
 
+    subtest 'limit_per_dist' => sub {
+        my $rs = $schema->resultset( 'Release' )->by_dist( 'My-Dist' )
+                ->limit_per_dist( 1 );
+        $rs->result_class( 'DBIx::Class::ResultClass::HashRefInflator' );
+        $schema->storage->debug(1);
+        is_deeply [ $rs->all ], [ $data{Release}[2] ], 'get maximum 1 item for My-Dist'
+            or diag explain [ $rs->all ];
+        $schema->storage->debug(0);
+    };
 };
 
 subtest 'by_author' => sub {


### PR DESCRIPTION
This PR is not to be merged; for review only.

@preaction As I've mentioned in IRC the technique of creating virtual "row numbers" with a subquery was not working, in the sense that it first assigned the sequence to releases, and then applied the other constraints. So a query for the most recent 4 releases of a dist, by_author X, might only return 3 results, if one of the most recent 4 releases were authored by Y.

This is solved in the case of `by_author` by passing that constraint into the sequence-generating sub-query, so only matching results are assigned a place in the sequence.

However, the same technique is not working for `distmat` (ie the `maturity` param), even though the SQL looks right.

I'm at a loss at the moment. And I start a new `$job` on Monday, and I have to do a bunch of boring admin work on a frikkin Drupal website I run for a club I'm in (sigh). So while I am not abandoning this issue, I wanted to post what I have so far so that if you have any time or desire, you can check it out and possibly even figure it out.


