### PR TITLE
Use MySQL 5.7 in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
         - perl: "5.24"
           env: COVERAGE=1 MYSQL_VERSION=5.7
         - perl: "blead"
-          env: COVERAGE=1 MYSQL_VERSION=5.7
+          env: MYSQL_VERSION=5.7
     allow_failures:
         - perl: "blead"
           env: MYSQL_VERSION=5.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: perl
-perl:
-    - "5.24"
-    - "blead"
 
 matrix:
     include:
         - perl: "5.24"
+          env: COVERAGE=1 MYSQL_VERSION=5.7
+        - perl: "blead"
           env: COVERAGE=1 MYSQL_VERSION=5.7
     allow_failures:
         - perl: "blead"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,24 @@ perl:
 matrix:
     include:
         - perl: "5.24"
-          env: COVERAGE=1
+          env: COVERAGE=1 MYSQL_VERSION=5.7
     allow_failures:
         - perl: "blead"
+          env: MYSQL_VERSION=5.7
 
 before_install:
+    - if [ x"$MYSQL_VERSION" != "x" ];
+      then
+        sudo service mysql stop;
+        sudo aptitude purge -y mysql-server libmysqlclient-dev mysql-server-5.6 mysql-common-5.6 mysql-client-5.6 libmysqlclient18 mysql-client-core-5.6 mysql-server-core-5.6 libdbd-mysql-perl mysql-common;
+        sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5;
+        . /etc/lsb-release;
+        sudo add-apt-repository "deb http://repo.mysql.com/apt/ubuntu/ $DISTRIB_CODENAME mysql-$MYSQL_VERSION";
+        sudo apt-get update;
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --fix-broken --allow-unauthenticated --option DPkg::Options::=--force-confnew install mysql-server libmysqlclient-dev;
+        sudo mysql_upgrade -u root --password='' --force;
+        sudo service mysql restart;
+      fi
     - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
     - source ~/travis-perl-helpers/init
     - build-perl


### PR DESCRIPTION
The tests require a MySQL version which supports JSON data structures.  This feature is only available from MySQL 5.7, whereas Travis installs version 5.6 by default.  The first change in this PR upgrades MySQL up to 5.7 so that the tests can pass.  The second change ensures that builds without environment variables aren't run unnecessarily.

This pull request is submitted in the hope that it is useful.  If anything needs to be changed, please just let me know and I'll be happy to update as required and resubmit.